### PR TITLE
UTF-8 encoding by default

### DIFF
--- a/7-latest/Dockerfile
+++ b/7-latest/Dockerfile
@@ -1,6 +1,14 @@
 FROM ubuntu:14.04
 
 #
+# UTF-8 by default
+#
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+#
 # Pull Zulu OpenJDK binaries from official repository:
 #
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9

--- a/7u72-7.7.0.1/Dockerfile
+++ b/7u72-7.7.0.1/Dockerfile
@@ -1,6 +1,14 @@
 FROM ubuntu:14.04
 
 #
+# UTF-8 by default
+#
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+#
 # Pull Zulu OpenJDK binaries from official repository:
 #
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9

--- a/8-latest/Dockerfile
+++ b/8-latest/Dockerfile
@@ -1,6 +1,14 @@
 FROM ubuntu:14.04
 
 #
+# UTF-8 by default
+#
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+#
 # Pull Zulu OpenJDK binaries from official repository:
 #
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9

--- a/8u25-8.4.0.1/Dockerfile
+++ b/8u25-8.4.0.1/Dockerfile
@@ -1,6 +1,14 @@
 FROM ubuntu:14.04
 
 #
+# UTF-8 by default
+#
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+#
 # Pull Zulu OpenJDK binaries from official repository:
 #
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9


### PR DESCRIPTION
The base Ubuntu image does not support UTF-8 encoded content.