### PR TITLE
Create alpine jre image

### DIFF
--- a/alpine-jre/8u162-8.27.0.7/Dockerfile
+++ b/alpine-jre/8u162-8.27.0.7/Dockerfile
@@ -1,0 +1,18 @@
+FROM frolvlad/alpine-glibc
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+RUN ZULU_ARCH=zulu8.27.0.7-jdk8.0.162-linux_x64.tar.gz && \
+	INSTALL_DIR=/usr/lib/jvm && \
+	BIN_DIR=/usr/bin && \
+	ZULU_DIR=$( basename ${ZULU_ARCH} .tar.gz ) && \
+	apk update && \
+	apk add --no-cache ca-certificates wget && \
+	update-ca-certificates && \
+	wget -q http://cdn.azul.com/zulu/bin/${ZULU_ARCH} && \
+	mkdir -p ${INSTALL_DIR} && \
+	tar -xf ./${ZULU_ARCH} -C /usr/lib/jvm/ && rm -f ${ZULU_ARCH} && \
+	rm -rf ${INSTALL_DIR}/${ZULU_DIR}/bin ${INSTALL_DIR}/${ZULU_DIR}/demo ${INSTALL_DIR}/${ZULU_DIR}/lib && \
+	rm -rf ${INSTALL_DIR}/${ZULU_DIR}/src.zip ${INSTALL_DIR}/${ZULU_DIR}/man && \
+	cd ${BIN_DIR}; find ${INSTALL_DIR}/${ZULU_DIR}/jre/bin -type f -perm -a=x -exec ln -s {} . \; && \
+	java -version 

--- a/alpine-jre/8u162-8.27.0.7/Dockerfile
+++ b/alpine-jre/8u162-8.27.0.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:glibc-2.27
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
Hi, 

removing some files and folders that are not needed to run java appliations I was able to reduce the size of the image from 190MB to 120MB.

For now I only created the Dockerfile for the latest Java 8 build, but this could possibly be made for other releases as well.

In addition to that i specified the version of frolvlad/alpine-glibc to keep the builds reproducible.