### PR TITLE
Alpine JDK8 Install Build Tools to Virtual

### DIFF
--- a/alpine/8-latest/8u172-8.30.0.1/Dockerfile
+++ b/alpine/8-latest/8u172-8.30.0.1/Dockerfile
@@ -8,7 +8,7 @@ RUN ZULU_ARCH=zulu8.30.0.1-jdk8.0.172-linux_x64.tar.gz && \
 	MAN_DIR=/usr/share/man/man1 && \
 	ZULU_DIR=$( basename ${ZULU_ARCH} .tar.gz ) && \
 	apk update && \
-	apk add --no-cache ca-certificates wget && \
+	apk add --no-cache --virtual=.build-dependencies ca-certificates wget && \
 	update-ca-certificates && \
 	wget -q http://cdn.azul.com/zulu/bin/${ZULU_ARCH} && \
 	mkdir -p ${INSTALL_DIR} && \
@@ -16,4 +16,5 @@ RUN ZULU_ARCH=zulu8.30.0.1-jdk8.0.172-linux_x64.tar.gz && \
 	cd ${BIN_DIR}; find ${INSTALL_DIR}/${ZULU_DIR}/bin -type f -perm -a=x -exec ln -s {} . \; && \
 	mkdir -p ${MAN_DIR} && \
 	cd ${MAN_DIR}; find ${INSTALL_DIR}/${ZULU_DIR}/man/man1 -type f -name "*.1" -exec ln -s {} . \; && \
+	apk del .build-dependencies && \
 	java -version 

--- a/alpine/8-latest/Dockerfile
+++ b/alpine/8-latest/Dockerfile
@@ -8,7 +8,7 @@ RUN ZULU_ARCH=zulu8.31.0.1-jdk8.0.181-linux_x64.tar.gz && \
 	MAN_DIR=/usr/share/man/man1 && \
 	ZULU_DIR=$( basename ${ZULU_ARCH} .tar.gz ) && \
 	apk update && \
-	apk add --no-cache ca-certificates wget && \
+	apk add --no-cache --virtual=.build-dependencies ca-certificates wget && \
 	update-ca-certificates && \
 	wget -q http://cdn.azul.com/zulu/bin/${ZULU_ARCH} && \
 	mkdir -p ${INSTALL_DIR} && \
@@ -16,4 +16,5 @@ RUN ZULU_ARCH=zulu8.31.0.1-jdk8.0.181-linux_x64.tar.gz && \
 	cd ${BIN_DIR}; find ${INSTALL_DIR}/${ZULU_DIR}/bin -type f -perm -a=x -exec ln -s {} . \; && \
 	mkdir -p ${MAN_DIR} && \
 	cd ${MAN_DIR}; find ${INSTALL_DIR}/${ZULU_DIR}/man/man1 -type f -name "*.1" -exec ln -s {} . \; && \
+	apk del .build-dependencies && \
 	java -version 


### PR DESCRIPTION
Install build tools for alpine 8-latest to virtual and remove the bundle after the image ready. This technique is already used in 9u07-9.0.7.1 and 10u01/02. Addresses #18.