### PR TITLE
alpine: fix ownership of JDK install

### DIFF
--- a/alpine/10u01-10.2/Dockerfile
+++ b/alpine/10u01-10.2/Dockerfile
@@ -26,6 +26,7 @@ RUN ZULU_ARCH=zulu10.2+3-jdk10.0.1-linux_x64.tar.gz && \
 	rm /root/.wget-hsts && \
 	mkdir -p ${INSTALL_DIR} && \
 	tar -xf ./${ZULU_ARCH} -C ${INSTALL_DIR} && rm -f ${ZULU_ARCH} && \
+	chown -R root:root ${INSTALL_DIR} && \
 	cd ${BIN_DIR} && find ${INSTALL_DIR}/${ZULU_DIR}/bin -type f -perm -a=x -exec ln -s {} . \; && \
 	mkdir -p ${MAN_DIR} && \
 	cd ${MAN_DIR} && find ${INSTALL_DIR}/${ZULU_DIR}/man/man1 -type f -name "*.1" -exec ln -s {} . \; && \

--- a/alpine/10u02-10.3/Dockerfile
+++ b/alpine/10u02-10.3/Dockerfile
@@ -26,6 +26,7 @@ RUN ZULU_ARCH=zulu10.3+5-jdk10.0.2-linux_x64.tar.gz && \
 	rm /root/.wget-hsts && \
 	mkdir -p ${INSTALL_DIR} && \
 	tar -xf ./${ZULU_ARCH} -C ${INSTALL_DIR} && rm -f ${ZULU_ARCH} && \
+	chown -R root:root ${INSTALL_DIR} && \
 	cd ${BIN_DIR} && find ${INSTALL_DIR}/${ZULU_DIR}/bin -type f -perm -a=x -exec ln -s {} . \; && \
 	mkdir -p ${MAN_DIR} && \
 	cd ${MAN_DIR} && find ${INSTALL_DIR}/${ZULU_DIR}/man/man1 -type f -name "*.1" -exec ln -s {} . \; && \


### PR DESCRIPTION
Zulu tarballs are created by user `tester:tester (500:500)` it seems
In the Alpine images we untar as root so this (incorrect) file ownership is restored
Busybox tar does not support `--owner=` 😞
So we must instead chown back to `root:root` manually

Many thanks