### PR TITLE
Alpine: Fix gcc-libs.tar.zst Deletion and Build Tools Install to Virtual

### DIFF
--- a/alpine/14.0.1-14.28.21/Dockerfile
+++ b/alpine/14.0.1-14.28.21/Dockerfile
@@ -10,19 +10,21 @@ RUN ZULU_PACK=${ZULU_DIR}.tar.gz && \
     INSTALL_DIR=/usr/lib/jvm && \
     BIN_DIR=/usr/bin && \
     MAN_DIR=/usr/share/man/man1 && \
-    apk --no-cache add binutils ca-certificates wget zstd tar xz && \
+    apk --no-cache add ca-certificates wget tar && \
+    apk --no-cache --virtual .build-deps add binutils zstd xz && \
     apk update && \
     apk upgrade && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && \
+    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && \
     apk add glibc-2.28-r0.apk && rm glibc-2.28-r0.apk && \
-    wget -O gcc-libs.tar.zst https://www.archlinux.org/packages/core/x86_64/gcc-libs/download/ && \
-    wget -O zlib.tar.xz https://www.archlinux.org/packages/core/x86_64/zlib/download/ && \
+    wget -q -O gcc-libs.tar.zst https://www.archlinux.org/packages/core/x86_64/gcc-libs/download/ && \
+    wget -q -O zlib.tar.xz https://www.archlinux.org/packages/core/x86_64/zlib/download/ && \
     tar -I zstd -xf gcc-libs.tar.zst -C /tmp && \
     tar -xJf zlib.tar.xz -C /tmp && \
     mv /tmp/usr/lib/libgcc_s.so* /tmp/usr/lib/libstdc++.so* /tmp/usr/lib/libz.so* /usr/glibc-compat/lib/ && \
     strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so.* && \
-    rm -rf gcc-libs.tar.xz zlib.tar.xz /tmp/usr && \
+    rm -rf gcc-libs.tar.zst zlib.tar.xz /tmp/usr && \
+    apk del .build-deps && \
     wget -q https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_musl_x64.tar.gz && rm /root/.wget-hsts && \
     mkdir -p ${INSTALL_DIR} && \
     tar -xf ./${ZULU_PACK} -C ${INSTALL_DIR} && rm -f ${ZULU_PACK} && \


### PR DESCRIPTION
Delete `gcc-libs.tar.zst` that was remaining in image because the extension was incorrect in the `rm` command. Also install build dependencies into virtual and delete them afterwards. Reduce image size by about 45MB.