### PR TITLE
Pin versions of Zulu for regularly updated releases

### DIFF
--- a/11.0.10-11.45.27/Dockerfile
+++ b/11.0.10-11.45.27/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu11-*\nPin: version 11.0.10-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.10-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/11.0.11-11.48.21/Dockerfile
+++ b/11.0.11-11.48.21/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu11-*\nPin: version 11.0.11-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.11-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/11.0.12-11.50.19/Dockerfile
+++ b/11.0.12-11.50.19/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu11-*\nPin: version 11.0.12-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.12-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/13.0.6-13.37.21/Dockerfile
+++ b/13.0.6-13.37.21/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu13-*\nPin: version 13.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu13-jdk=13.0.6-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/13.0.7-13.40.15/Dockerfile
+++ b/13.0.7-13.40.15/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu13-*\nPin: version 13.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu13-jdk=13.0.7-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/13.0.8-13.42.17/Dockerfile
+++ b/13.0.8-13.42.17/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu13-*\nPin: version 13.0.8-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu13-jdk=13.0.8-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/15.0.2-15.29.15/Dockerfile
+++ b/15.0.2-15.29.15/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu15-*\nPin: version 15.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu15-jdk=15.0.2-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/15.0.3-15.32.15/Dockerfile
+++ b/15.0.3-15.32.15/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu15-*\nPin: version 15.0.3-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu15-jdk=15.0.3-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/15.0.4-15.34.17/Dockerfile
+++ b/15.0.4-15.34.17/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu15-*\nPin: version 15.0.4-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu15-jdk=15.0.4-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/16.0.2-16.32.15/Dockerfile
+++ b/16.0.2-16.32.15/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu16-*\nPin: version 16.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu16-jdk=16.0.2-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/7u292-7.44.0.11/Dockerfile
+++ b/7u292-7.44.0.11/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu7-*\nPin: version 7.0.292-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu7-jdk=7.0.292-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/7u302-7.46.0.11/Dockerfile
+++ b/7u302-7.46.0.11/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu7-*\nPin: version 7.0.302-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu7-jdk=7.0.302-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/7u312-7.48.0.11/Dockerfile
+++ b/7u312-7.48.0.11/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu7-*\nPin: version 7.0.312-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu7-jdk=7.0.312-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/8u282-8.52.0.23/Dockerfile
+++ b/8u282-8.52.0.23/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu8-*\nPin: version 8.0.282-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.282-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \

--- a/8u302-8.56.0.21/Dockerfile
+++ b/8u302-8.56.0.21/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq update && \
     apt-get -qq update && \
     apt-get -qq -y dist-upgrade && \
     mkdir -p /usr/share/man/man1 && \
+    echo -e "Package: zulu8-*\nPin: version 8.0.302-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.302-* && \
     apt-get -qq -y purge gnupg software-properties-common curl && \
     apt -y autoremove && \


### PR DESCRIPTION
Create file /etc/apt/preferences and pin versions of Zulu packages there. It should fix the ability to update Docker images on regular basis.