### PR TITLE
Update alpine docker files to 3.16

### DIFF
--- a/alpine/11-jre-headless-latest/Dockerfile
+++ b/alpine/11-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/11-jre-latest/Dockerfile
+++ b/alpine/11-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/11-latest/Dockerfile
+++ b/alpine/11-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/11.0.17-11.60.19-jre-headless/Dockerfile_x86
+++ b/alpine/11.0.17-11.60.19-jre-headless/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/11.0.17-11.60.19-jre/Dockerfile_x86
+++ b/alpine/11.0.17-11.60.19-jre/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/11.0.17-11.60.19/Dockerfile_x86
+++ b/alpine/11.0.17-11.60.19/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17-jre-headless-latest/Dockerfile
+++ b/alpine/17-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17-jre-latest/Dockerfile
+++ b/alpine/17-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17-latest/Dockerfile
+++ b/alpine/17-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17.0.5-17.38.21-jre-headless/Dockerfile_arm64
+++ b/alpine/17.0.5-17.38.21-jre-headless/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17.0.5-17.38.21-jre-headless/Dockerfile_x86
+++ b/alpine/17.0.5-17.38.21-jre-headless/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17.0.5-17.38.21-jre/Dockerfile_arm64
+++ b/alpine/17.0.5-17.38.21-jre/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17.0.5-17.38.21-jre/Dockerfile_x86
+++ b/alpine/17.0.5-17.38.21-jre/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17.0.5-17.38.21/Dockerfile_arm64
+++ b/alpine/17.0.5-17.38.21/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/17.0.5-17.38.21/Dockerfile_x86
+++ b/alpine/17.0.5-17.38.21/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18-jre-headless-latest/Dockerfile
+++ b/alpine/18-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18-jre-latest/Dockerfile
+++ b/alpine/18-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18-latest/Dockerfile
+++ b/alpine/18-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18.0.2.1-18.32.13-jre-headless/Dockerfile_arm64
+++ b/alpine/18.0.2.1-18.32.13-jre-headless/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18.0.2.1-18.32.13-jre-headless/Dockerfile_x86
+++ b/alpine/18.0.2.1-18.32.13-jre-headless/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18.0.2.1-18.32.13-jre/Dockerfile_arm64
+++ b/alpine/18.0.2.1-18.32.13-jre/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18.0.2.1-18.32.13-jre/Dockerfile_x86
+++ b/alpine/18.0.2.1-18.32.13-jre/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18.0.2.1-18.32.13/Dockerfile_arm64
+++ b/alpine/18.0.2.1-18.32.13/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/18.0.2.1-18.32.13/Dockerfile_x86
+++ b/alpine/18.0.2.1-18.32.13/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19-jre-headless-latest/Dockerfile
+++ b/alpine/19-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19-jre-latest/Dockerfile
+++ b/alpine/19-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19-latest/Dockerfile
+++ b/alpine/19-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19.0.1-19.30.11-jre-headless/Dockerfile_arm64
+++ b/alpine/19.0.1-19.30.11-jre-headless/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19.0.1-19.30.11-jre-headless/Dockerfile_x86
+++ b/alpine/19.0.1-19.30.11-jre-headless/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19.0.1-19.30.11-jre/Dockerfile_arm64
+++ b/alpine/19.0.1-19.30.11-jre/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19.0.1-19.30.11-jre/Dockerfile_x86
+++ b/alpine/19.0.1-19.30.11-jre/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19.0.1-19.30.11/Dockerfile_arm64
+++ b/alpine/19.0.1-19.30.11/Dockerfile_arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/19.0.1-19.30.11/Dockerfile_x86
+++ b/alpine/19.0.1-19.30.11/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/8-jre-headless-latest/Dockerfile
+++ b/alpine/8-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/8-jre-latest/Dockerfile
+++ b/alpine/8-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/8-latest/Dockerfile
+++ b/alpine/8-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/8u352-8.66.0.15-jre-headless/Dockerfile_x86
+++ b/alpine/8u352-8.66.0.15-jre-headless/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/8u352-8.66.0.15-jre/Dockerfile_x86
+++ b/alpine/8u352-8.66.0.15-jre/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/alpine/8u352-8.66.0.15/Dockerfile_x86
+++ b/alpine/8u352-8.66.0.15/Dockerfile_x86
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
There was discussion on another PR about updating the alpine tags to point to `3` or `latest` directly, but since the discussion didn't reach a conclusion I have simply moved these images to `3.16`