### PR TITLE
use symlink instead of hardcoded amd64 for JAVA_HOME env

### DIFF
--- a/ubuntu/18-jre-headless-latest/Dockerfile
+++ b/ubuntu/18-jre-headless-latest/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18-jre-headless-latest/latest.md
+++ b/ubuntu/18-jre-headless-latest/latest.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18-jre-latest/Dockerfile
+++ b/ubuntu/18-jre-latest/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18-jre-latest/latest.md
+++ b/ubuntu/18-jre-latest/latest.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18-latest/Dockerfile
+++ b/ubuntu/18-latest/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18-latest/latest.md
+++ b/ubuntu/18-latest/latest.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.1-18.30.11-jre-headless/18.30.11_x86.md
+++ b/ubuntu/18.0.1-18.30.11-jre-headless/18.30.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.1-18.30.11-jre-headless/Dockerfile
+++ b/ubuntu/18.0.1-18.30.11-jre-headless/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.1-18.30.11-jre/18.30.11_x86.md
+++ b/ubuntu/18.0.1-18.30.11-jre/18.30.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.1-18.30.11-jre/Dockerfile
+++ b/ubuntu/18.0.1-18.30.11-jre/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.1-18.30.11/18.30.11_x86.md
+++ b/ubuntu/18.0.1-18.30.11/18.30.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.1-18.30.11/Dockerfile
+++ b/ubuntu/18.0.1-18.30.11/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.2-18.32.11-jre-headless/18.32.11_x86.md
+++ b/ubuntu/18.0.2-18.32.11-jre-headless/18.32.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.2-18.32.11-jre-headless/Dockerfile
+++ b/ubuntu/18.0.2-18.32.11-jre-headless/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.2-18.32.11-jre/18.32.11_x86.md
+++ b/ubuntu/18.0.2-18.32.11-jre/18.32.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.2-18.32.11-jre/Dockerfile
+++ b/ubuntu/18.0.2-18.32.11-jre/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.2-18.32.11/18.32.11_x86.md
+++ b/ubuntu/18.0.2-18.32.11/18.32.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.2-18.32.11/Dockerfile
+++ b/ubuntu/18.0.2-18.32.11/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.2.1-18.32.13-jre-headless/18.32.13_x86.md
+++ b/ubuntu/18.0.2.1-18.32.13-jre-headless/18.32.13_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.2.1-18.32.13-jre-headless/Dockerfile
+++ b/ubuntu/18.0.2.1-18.32.13-jre-headless/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.2.1-18.32.13-jre/18.32.13_x86.md
+++ b/ubuntu/18.0.2.1-18.32.13-jre/18.32.13_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.2.1-18.32.13-jre/Dockerfile
+++ b/ubuntu/18.0.2.1-18.32.13-jre/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/18.0.2.1-18.32.13/18.32.13_x86.md
+++ b/ubuntu/18.0.2.1-18.32.13/18.32.13_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu18`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/18.0.2.1-18.32.13/Dockerfile
+++ b/ubuntu/18.0.2.1-18.32.13/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu18-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu18

--- a/ubuntu/19-jre-headless-latest/Dockerfile
+++ b/ubuntu/19-jre-headless-latest/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19-jre-headless-latest/latest.md
+++ b/ubuntu/19-jre-headless-latest/latest.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19-jre-latest/Dockerfile
+++ b/ubuntu/19-jre-latest/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19-jre-latest/latest.md
+++ b/ubuntu/19-jre-latest/latest.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19-latest/Dockerfile
+++ b/ubuntu/19-latest/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19-latest/latest.md
+++ b/ubuntu/19-latest/latest.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.0-19.28.81-jre-headless/19.28.81_x86.md
+++ b/ubuntu/19.0.0-19.28.81-jre-headless/19.28.81_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.0-19.28.81-jre-headless/Dockerfile
+++ b/ubuntu/19.0.0-19.28.81-jre-headless/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.0-19.28.81-jre/19.28.81_x86.md
+++ b/ubuntu/19.0.0-19.28.81-jre/19.28.81_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.0-19.28.81-jre/Dockerfile
+++ b/ubuntu/19.0.0-19.28.81-jre/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.0-19.28.81/19.28.81_x86.md
+++ b/ubuntu/19.0.0-19.28.81/19.28.81_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.0-19.28.81/Dockerfile
+++ b/ubuntu/19.0.0-19.28.81/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.1-19.30.11-jre-headless/19.30.11_x86.md
+++ b/ubuntu/19.0.1-19.30.11-jre-headless/19.30.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.1-19.30.11-jre-headless/Dockerfile
+++ b/ubuntu/19.0.1-19.30.11-jre-headless/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.1-19.30.11-jre/19.30.11_x86.md
+++ b/ubuntu/19.0.1-19.30.11-jre/19.30.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.1-19.30.11-jre/Dockerfile
+++ b/ubuntu/19.0.1-19.30.11-jre/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.1-19.30.11/19.30.11_x86.md
+++ b/ubuntu/19.0.1-19.30.11/19.30.11_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.1-19.30.11/Dockerfile
+++ b/ubuntu/19.0.1-19.30.11/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.2-19.32.13-jre-headless/19.32.13_x86.md
+++ b/ubuntu/19.0.2-19.32.13-jre-headless/19.32.13_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.2-19.32.13-jre-headless/Dockerfile
+++ b/ubuntu/19.0.2-19.32.13-jre-headless/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.2-19.32.13-jre/19.32.13_x86.md
+++ b/ubuntu/19.0.2-19.32.13-jre/19.32.13_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.2-19.32.13-jre/Dockerfile
+++ b/ubuntu/19.0.2-19.32.13-jre/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.2-19.32.13/19.32.13_x86.md
+++ b/ubuntu/19.0.2-19.32.13/19.32.13_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.2-19.32.13/Dockerfile
+++ b/ubuntu/19.0.2-19.32.13/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19

--- a/ubuntu/19.0.2-19.32.15/19.32.15_x86.md
+++ b/ubuntu/19.0.2-19.32.15/19.32.15_x86.md
@@ -13,7 +13,7 @@
   - `LANG=en_US.UTF-8`
   - `LANGUAGE=en_US:en`
   - `LC_ALL=en_US.UTF-8`
-  - `JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64`
+  - `JAVA_HOME=/usr/lib/jvm/zulu19`
 
 ## `dpkg` (`.deb`-based packages)
 

--- a/ubuntu/19.0.2-19.32.15/Dockerfile
+++ b/ubuntu/19.0.2-19.32.15/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get -qq update && \
     apt -y autoremove && \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 
-ENV JAVA_HOME=/usr/lib/jvm/zulu19-ca-amd64
+ENV JAVA_HOME=/usr/lib/jvm/zulu19


### PR DESCRIPTION
The commit that moved ubuntu to a separate folder (269dca0) did not adjust the `JAVA_HOME` env var to use the symlink to the JVM directory, but hardcodes amd64 instead, which requries ARM-builds to manually specify `JAVA_HOME` (thereby, as in my case, potentially breaking downstream).

In case this was just an oversight and not by design, here is a PR