### PR TITLE
Reduce readme file size to fit Dockerhub repository description limit

### DIFF
--- a/alpine/README.j2
+++ b/alpine/README.j2
@@ -33,14 +33,16 @@ Most Recent
 Previous
 --------
 
-Earlier Alpine Docker image tags of Azul Zulu for previous update releases of OpenJDK are as follows:
+Earlier Alpine Docker image tags (the most recent 4 tags) of Azul Zulu for previous update releases of OpenJDK are as follows:
 
 {% for version in versions -%}
   {% set items = links[version].items() %}
-  * {% for item in items -%}
+  * {%- for item in items -%}
+    {%- if loop.index <= 4 -%}
     [{{ item[1][0] }}][{{ item[0] }}],
+    {%- endif %}
   {% endfor %}
-{%- endfor %}
+{%- endfor -%}
 
 **Note**: Some of these may use glibc and predate the move to musl libc.
 
@@ -55,7 +57,6 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 
 [BSD 3-Clause Clear License][10]
 
-
   [1]: https://www.azul.com/
   [2]: https://www.azul.com/products/core/
   [3]: https://docs.azul.com/core/
@@ -69,6 +70,8 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 
 {% for major_ver, body in links.items() %}
   {% for (num, ver) in body.items() -%}
-    [{{ num }}]: {{ ver[1] }}
+    {%- if loop.index <= 4 -%}
+      [{{ num }}]: {{ ver[1] }}
+    {%- endif %}
   {% endfor -%}
 {% endfor %}

--- a/centos/README.j2
+++ b/centos/README.j2
@@ -4,7 +4,7 @@ Azul Zulu CentOS
 These Docker images of Azul Zulu Build of OpenJDK are based on CentOS.
 
 Azul Zulu Builds of OpenJDK are available for free unlimited use and are commercially supported by [Azul][1] as a part of the Azul Platform Core bundle.
-                                Check out [Azul Platform Core][2] for more information. The technical documentation can be found on [docs.azul.com/core][3].
+Check out [Azul Platform Core][2] for more information. The technical documentation can be found on [docs.azul.com/core][3].
 
 Docker images of Azul Zulu are available in the following repositories, depending on the base system:
 
@@ -20,26 +20,28 @@ Tags and `Dockerfile` links
 Most Recent
 -----------
 
- {% for version in versions -%}
-   {% if 'jre' not in version -%}
-     {% set keys = links[version].keys() | list %}
-     {%- set values = links[version].values() | list %}
-     {%- set url_split = (values)[0][1].split('/') %}
-   * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
-   {%- endif %}
- {%- endfor %}
+{% for version in versions -%}
+  {% if 'jre' not in version -%}
+    {% set keys = links[version].keys() | list %}
+    {%- set values = links[version].values() | list %}
+    {%- set url_split = (values)[0][1].split('/') %}
+  * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+  {%- endif %}
+{%- endfor %}
 
 Previous
 --------
 
-Earlier CentOS Docker image tags of Azul Zulu for previous update releases of OpenJDK are as follows:
+Earlier CentOS Docker image tags(the most recent 4 tags) of Azul Zulu for previous update releases of OpenJDK are as follows:
 
 {% for version in versions -%}
   {% set items = links[version].items() %}
-  * {% for item in items -%}
+  * {%- for item in items -%}
+    {%- if loop.index <= 4 -%}
     [{{ item[1][0] }}][{{ item[0] }}],
+    {%- endif %}
   {% endfor %}
-{%- endfor %}
+{%- endfor -%}
 
 License
 =======
@@ -65,6 +67,8 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 
 {% for major_ver, body in links.items() %}
   {% for (num, ver) in body.items() -%}
-    [{{ num }}]: {{ ver[1] }}
+    {%- if loop.index <= 4 -%}
+      [{{ num }}]: {{ ver[1] }}
+    {%- endif %}
   {% endfor -%}
 {% endfor %}

--- a/debian/README.j2
+++ b/debian/README.j2
@@ -32,14 +32,16 @@ Most Recent
 Previous
 --------
 
-Earlier Debian Docker image tags of Azul Zulu for previous update releases of OpenJDK are as follows:
+Earlier Debian Docker image tags(the most recent 4 tags) of Azul Zulu for previous update releases of OpenJDK are as follows:
 
 {% for version in versions -%}
   {% set items = links[version].items() %}
-  * {% for item in items -%}
+  * {%- for item in items -%}
+    {%- if loop.index <= 4 -%}
     [{{ item[1][0] }}][{{ item[0] }}],
+    {%- endif %}
   {% endfor %}
-{%- endfor %}
+{%- endfor -%}
 
 License
 =======
@@ -65,6 +67,8 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 
 {% for major_ver, body in links.items() %}
   {% for (num, ver) in body.items() -%}
-    [{{ num }}]: {{ ver[1] }}
+    {%- if loop.index <= 4 -%}
+      [{{ num }}]: {{ ver[1] }}
+    {%- endif %}
   {% endfor -%}
 {% endfor %}

--- a/distroless/README.j2
+++ b/distroless/README.j2
@@ -33,14 +33,16 @@ Most Recent
 Previous
 --------
 
-Earlier Distroless Docker image tags of Azul Zulu for previous update releases of OpenJDK are as follows:
+Earlier Distroless Docker image tags(the most recent 4 tags) of Azul Zulu for previous update releases of OpenJDK are as follows:
 
 {% for version in versions -%}
   {% set items = links[version].items() %}
-  * {% for item in items -%}
+  * {%- for item in items -%}
+    {%- if loop.index <= 4 -%}
     [{{ item[1][0] }}][{{ item[0] }}],
+    {%- endif %}
   {% endfor %}
-{%- endfor %}
+{%- endfor -%}
 
 License
 =======
@@ -67,6 +69,8 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 
 {% for major_ver, body in links.items() %}
   {% for (num, ver) in body.items() -%}
-    [{{ num }}]: {{ ver[1] }}
+    {%- if loop.index <= 4 -%}
+      [{{ num }}]: {{ ver[1] }}
+    {%- endif %}
   {% endfor -%}
 {% endfor %}

--- a/ubuntu/README.j2
+++ b/ubuntu/README.j2
@@ -32,15 +32,16 @@ Most Recent
 Previous
 --------
 
-Earlier Ubuntu Docker image tags of Azul Zulu for previous update releases of OpenJDK are as follows:
+Earlier Ubuntu Docker image tags(the most recent 4 tags) of Azul Zulu for previous update releases of OpenJDK are as follows:
 
 {% for version in versions -%}
   {% set items = links[version].items() %}
-  * {% for item in items -%}
+  * {%- for item in items -%}
+    {%- if loop.index <= 4 -%}
     [{{ item[1][0] }}][{{ item[0] }}],
+    {%- endif %}
   {% endfor %}
-{%- endfor %}
-
+{%- endfor -%}
 
 License
 =======
@@ -66,6 +67,8 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 
 {% for major_ver, body in links.items() %}
   {% for (num, ver) in body.items() -%}
-    [{{ num }}]: {{ ver[1] }}
+    {%- if loop.index <= 4 -%}
+      [{{ num }}]: {{ ver[1] }}
+    {%- endif %}
   {% endfor -%}
 {% endfor %}


### PR DESCRIPTION
Reduce readme file size to fit Dockerhub repository description limit 25kb.
The list image tags limited to 4 the most recent.