### PR TITLE
Update readmegen.py to fix release versions order

### DIFF
--- a/alpine/README.j2
+++ b/alpine/README.j2
@@ -21,12 +21,18 @@ Tags and `Dockerfile` links
 Most Recent
 -----------
 
-{% for version in versions -%}
-  {% if 'jre' not in version -%}
+{% set ns = namespace(not_latest=False) %}
+{% for version in versions  -%}
+  {% if ( 'jre' not in version and 'crac' not in version ) -%}
     {% set keys = links[version].keys() | list %}
     {%- set values = links[version].values() | list %}
     {%- set url_split = (values)[0][1].split('/') %}
-  * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% if not ns.not_latest %}
+      {% set ns.not_latest = True %}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% elif (version[:1] == '8' or version[:2] in ['11', '17', '21']) or ( version[:2]|int > 21 and (version[:2]|int -21) % 4 == 0) and ns.not_latest -%}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {%- endif %}
   {%- endif %}
 {%- endfor %}
 

--- a/centos/README.j2
+++ b/centos/README.j2
@@ -20,12 +20,18 @@ Tags and `Dockerfile` links
 Most Recent
 -----------
 
-{% for version in versions -%}
-  {% if 'jre' not in version -%}
+{% set ns = namespace(not_latest=False) %}
+{% for version in versions  -%}
+  {% if ( 'jre' not in version and 'crac' not in version ) -%}
     {% set keys = links[version].keys() | list %}
     {%- set values = links[version].values() | list %}
     {%- set url_split = (values)[0][1].split('/') %}
-  * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% if not ns.not_latest %}
+      {% set ns.not_latest = True %}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% elif (version[:1] == '8' or version[:2] in ['11', '17', '21']) or ( version[:2]|int > 21 and (version[:2]|int -21) % 4 == 0) and ns.not_latest -%}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {%- endif %}
   {%- endif %}
 {%- endfor %}
 

--- a/debian/README.j2
+++ b/debian/README.j2
@@ -20,12 +20,18 @@ Tags and `Dockerfile` links
 Most Recent
 -----------
 
-{% for version in versions -%}
-  {% if 'jre' not in version -%}
+{% set ns = namespace(not_latest=False) %}
+{% for version in versions  -%}
+  {% if ( 'jre' not in version and 'crac' not in version ) -%}
     {% set keys = links[version].keys() | list %}
     {%- set values = links[version].values() | list %}
     {%- set url_split = (values)[0][1].split('/') %}
-  * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% if not ns.not_latest %}
+      {% set ns.not_latest = True %}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% elif (version[:1] == '8' or version[:2] in ['11', '17', '21']) or ( version[:2]|int > 21 and (version[:2]|int -21) % 4 == 0) and ns.not_latest -%}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {%- endif %}
   {%- endif %}
 {%- endfor %}
 

--- a/distroless/README.j2
+++ b/distroless/README.j2
@@ -21,14 +21,20 @@ Tags and `Dockerfile` links
 Most Recent
 -----------
 
- {% for version in versions -%}
-   {% if 'jre' not in version -%}
-     {% set keys = links[version].keys() | list %}
-     {%- set values = links[version].values() | list %}
-     {%- set url_split = (values)[0][1].split('/') %}
-   * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
-   {%- endif %}
- {%- endfor %}
+{% set ns = namespace(not_latest=False) %}
+{% for version in versions  -%}
+  {% if ( 'jre' not in version and 'crac' not in version ) -%}
+    {% set keys = links[version].keys() | list %}
+    {%- set values = links[version].values() | list %}
+    {%- set url_split = (values)[0][1].split('/') %}
+    {% if not ns.not_latest %}
+      {% set ns.not_latest = True %}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% elif (version[:1] == '8' or version[:2] in ['11', '17', '21']) or ( version[:2]|int > 21 and (version[:2]|int -21) % 4 == 0) and ns.not_latest -%}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {%- endif %}
+  {%- endif %}
+{%- endfor %}
 
 Previous
 --------

--- a/readmegen.py
+++ b/readmegen.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import re
 
 from jinja2 import Template
 
@@ -24,12 +25,21 @@ versions = sorted([ver.removesuffix('-latest') for ver in ver_path_dict.keys() i
                   key=lambda version: '{0:0>90}'.format(version).lower())
 versions.reverse()
 
-# Created a sorted list of versions
+# Create a list of tuples from ver_path_dict. Add a third element to each tuple ('digit_parts') to use for sorting
+ver_path_list = []
+for x in list(ver_path_dict.items()):
+    split_val = re.split(r'[.\-a-zA-Z]', x[0])
+    digit_parts = tuple([int(num) for num in split_val if num.isdigit()])
+    ver_path_list += [x + (digit_parts,)]
+
+# Sort ver_path_list first according to major verions, and then according to 'digit_parts'. Remove 'digit_parts' after sort
+# versions_list will be like [('22-latest', '<url>'), ..., ('22.0.0-22.28', '<url>'), ..., ('22.0.1-22.30', '<url>'), .., ('21-latest', '<url>'), ...]
 versions_list = []
 for ver in versions:
-    versions_list += sorted([x for x in ver_path_dict.items()
-                             if x[0][0] == ver or x[0][0:2] == ver],
-                            key=lambda version: '{0:0>90}'.format(version[0]).lower())
+    versions_list += [x[:2] for x in ver_path_list if x[0] == f"{ver}-latest"]
+    versions_list += [x[:2] for x in sorted(ver_path_list,
+                                            key=lambda version: version[2])
+                    if x[0] != f"{ver}-latest" and ( x[0][0] == ver or x[0][:2] == ver )]
 
 # Enumerate items in the list with versions to use it in template as pointers to links
 num_ver_dict = {}

--- a/ubuntu/README.j2
+++ b/ubuntu/README.j2
@@ -20,12 +20,18 @@ Tags and `Dockerfile` links
 Most Recent
 -----------
 
+{% set ns = namespace(not_latest=False) %}
 {% for version in versions  -%}
   {% if ( 'jre' not in version and 'crac' not in version ) -%}
     {% set keys = links[version].keys() | list %}
     {%- set values = links[version].values() | list %}
     {%- set url_split = (values)[0][1].split('/') %}
-  * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% if not ns.not_latest %}
+      {% set ns.not_latest = True %}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {% elif (version[:1] == '8' or version[:2] in ['11', '17', '21']) or ( version[:2]|int > 21 and (version[:2]|int -21) % 4 == 0) and ns.not_latest -%}
+    * [`{{ (values)[-1][0] }}`, `{{ (values)[0][0] }}` (*{{ url_split[-2] }}/{{ url_split[-1] }})*][{{ (keys)[0] }}]
+    {%- endif %}
   {%- endif %}
 {%- endfor %}
 


### PR DESCRIPTION
Changed version release sorting in `readmegen.py` to:
1. Split release name by `.` or `-` or alphabets & store as tuples
2. Use these tuples (`digits_part`) to sort list containing version names & Dockerfile paths
3. `versions_list` is sorted first by major versions like [22, 21, 20, ..]. For each major version, the first release is {version}-latest followed by oldest to newest releases of that version. (Ordered this because the jinja template expects them in this order)

Changed `README.j2` to display the newest version & all LTS versions in the 'Most Recent' section.