### PR TITLE
Improvements for Docker images

### DIFF
--- a/alpine/11-jre-headless-latest/Dockerfile
+++ b/alpine/11-jre-headless-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu11-jre-headless~=11.0.26 tzdata
 

--- a/alpine/11-jre-latest/Dockerfile
+++ b/alpine/11-jre-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu11-jre~=11.0.26 tzdata
 

--- a/alpine/11-latest/Dockerfile
+++ b/alpine/11-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu11-jdk~=11.0.26 tzdata
 

--- a/alpine/11.0.26-11.78-jre-headless/Dockerfile
+++ b/alpine/11.0.26-11.78-jre-headless/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu11-jre-headless~=11.0.26 tzdata
 

--- a/alpine/11.0.26-11.78-jre/Dockerfile
+++ b/alpine/11.0.26-11.78-jre/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu11-jre~=11.0.26 tzdata
 

--- a/alpine/11.0.26-11.78/Dockerfile
+++ b/alpine/11.0.26-11.78/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu11-jdk~=11.0.26 tzdata
 

--- a/alpine/17-jre-headless-latest/Dockerfile
+++ b/alpine/17-jre-headless-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu17-jre-headless~=17.0.14 tzdata
 

--- a/alpine/17-jre-latest/Dockerfile
+++ b/alpine/17-jre-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu17-jre~=17.0.14 tzdata
 

--- a/alpine/17-latest/Dockerfile
+++ b/alpine/17-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu17-jdk~=17.0.14 tzdata
 

--- a/alpine/17.0.14-17.56-jre-headless/Dockerfile
+++ b/alpine/17.0.14-17.56-jre-headless/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu17-jre-headless~=17.0.14 tzdata
 

--- a/alpine/17.0.14-17.56-jre/Dockerfile
+++ b/alpine/17.0.14-17.56-jre/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu17-jre~=17.0.14 tzdata
 

--- a/alpine/17.0.14-17.56/Dockerfile
+++ b/alpine/17.0.14-17.56/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu17-jdk~=17.0.14 tzdata
 

--- a/alpine/21-jre-headless-latest/Dockerfile
+++ b/alpine/21-jre-headless-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu21-jre-headless~=21.0.6 tzdata
 

--- a/alpine/21-jre-latest/Dockerfile
+++ b/alpine/21-jre-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu21-jre~=21.0.6 tzdata
 

--- a/alpine/21-latest/Dockerfile
+++ b/alpine/21-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu21-jdk~=21.0.6 tzdata
 

--- a/alpine/21.0.6-21.40-jre-headless/Dockerfile
+++ b/alpine/21.0.6-21.40-jre-headless/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu21-jre-headless~=21.0.6 tzdata
 

--- a/alpine/21.0.6-21.40-jre/Dockerfile
+++ b/alpine/21.0.6-21.40-jre/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu21-jre~=21.0.6 tzdata
 

--- a/alpine/21.0.6-21.40/Dockerfile
+++ b/alpine/21.0.6-21.40/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu21-jdk~=21.0.6 tzdata
 

--- a/alpine/22-jre-headless-latest/Dockerfile
+++ b/alpine/22-jre-headless-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu22-jre-headless~=22.0.2 tzdata
 

--- a/alpine/22-jre-latest/Dockerfile
+++ b/alpine/22-jre-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu22-jre~=22.0.2 tzdata
 

--- a/alpine/22-latest/Dockerfile
+++ b/alpine/22-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu22-jdk~=22.0.2 tzdata
 

--- a/alpine/22.0.2-22.32-jre-headless/Dockerfile
+++ b/alpine/22.0.2-22.32-jre-headless/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu22-jre-headless~=22.0.2 tzdata
 

--- a/alpine/22.0.2-22.32-jre/Dockerfile
+++ b/alpine/22.0.2-22.32-jre/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu22-jre~=22.0.2 tzdata
 

--- a/alpine/22.0.2-22.32/Dockerfile
+++ b/alpine/22.0.2-22.32/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu22-jdk~=22.0.2 tzdata
 

--- a/alpine/23-jre-headless-latest/Dockerfile
+++ b/alpine/23-jre-headless-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu23-jre-headless~=23.0.2 tzdata
 

--- a/alpine/23-jre-latest/Dockerfile
+++ b/alpine/23-jre-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu23-jre~=23.0.2 tzdata
 

--- a/alpine/23-latest/Dockerfile
+++ b/alpine/23-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu23-jdk~=23.0.2 tzdata
 

--- a/alpine/23.0.2-23.32-jre-headless/Dockerfile
+++ b/alpine/23.0.2-23.32-jre-headless/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu23-jre-headless~=23.0.2 tzdata
 

--- a/alpine/23.0.2-23.32-jre/Dockerfile
+++ b/alpine/23.0.2-23.32-jre/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu23-jre~=23.0.2 tzdata
 

--- a/alpine/23.0.2-23.32/Dockerfile
+++ b/alpine/23.0.2-23.32/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu23-jdk~=23.0.2 tzdata
 

--- a/alpine/24-jre-headless-latest/Dockerfile
+++ b/alpine/24-jre-headless-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu24-jre-headless~=24.0.0 tzdata
 

--- a/alpine/24-jre-latest/Dockerfile
+++ b/alpine/24-jre-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu24-jre~=24.0.0 tzdata
 

--- a/alpine/24-latest/Dockerfile
+++ b/alpine/24-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu24-jdk~=24.0.0 tzdata
 

--- a/alpine/24.0.0-24.28-jre-headless/Dockerfile
+++ b/alpine/24.0.0-24.28-jre-headless/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu24-jre-headless~=24.0.0 tzdata
 

--- a/alpine/24.0.0-24.28-jre/Dockerfile
+++ b/alpine/24.0.0-24.28-jre/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu24-jre~=24.0.0 tzdata
 

--- a/alpine/24.0.0-24.28/Dockerfile
+++ b/alpine/24.0.0-24.28/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu24-jdk~=24.0.0 tzdata
 

--- a/alpine/8-jre-headless-latest/Dockerfile
+++ b/alpine/8-jre-headless-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu8-jre-headless~=8.0.442 tzdata
 

--- a/alpine/8-jre-latest/Dockerfile
+++ b/alpine/8-jre-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu8-jre~=8.0.442 tzdata
 

--- a/alpine/8-latest/Dockerfile
+++ b/alpine/8-latest/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu8-jdk~=8.0.442 tzdata
 

--- a/alpine/8u442-8.84-jre-headless/Dockerfile
+++ b/alpine/8u442-8.84-jre-headless/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu8-jre-headless~=8.0.442 tzdata
 

--- a/alpine/8u442-8.84-jre/Dockerfile
+++ b/alpine/8u442-8.84-jre/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu8-jre~=8.0.442 tzdata
 

--- a/alpine/8u442-8.84/Dockerfile
+++ b/alpine/8u442-8.84/Dockerfile
@@ -1,11 +1,10 @@
 FROM alpine:3.20
 
 ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV TZ=Etc/UTC
 ARG ZULU_KEY_SHA256=6c6393d4755818a15cf055a5216cffa599f038cd508433faed2226925956509a
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
+RUN set -ex && \
+    apk update && apk upgrade --no-cache && \
+    wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/ && \
     echo "${ZULU_KEY_SHA256}  /etc/apk/keys/alpine-signing@azul.com-5d5dc44c.rsa.pub" | sha256sum -c - && \
     apk --repository https://repos.azul.com/zulu/alpine --no-cache add zulu8-jdk~=8.0.442 tzdata
 

--- a/centos/11-jre-headless-latest/Dockerfile
+++ b/centos/11-jre-headless-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/11-jre-latest/Dockerfile
+++ b/centos/11-jre-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/11-latest/Dockerfile
+++ b/centos/11-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/11.0.26-11.78-jre-headless/Dockerfile
+++ b/centos/11.0.26-11.78-jre-headless/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/11.0.26-11.78-jre/Dockerfile
+++ b/centos/11.0.26-11.78-jre/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/11.0.26-11.78/Dockerfile
+++ b/centos/11.0.26-11.78/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/17-jre-headless-latest/Dockerfile
+++ b/centos/17-jre-headless-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/17-jre-latest/Dockerfile
+++ b/centos/17-jre-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/17-latest/Dockerfile
+++ b/centos/17-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/17.0.14-17.56-jre-headless/Dockerfile
+++ b/centos/17.0.14-17.56-jre-headless/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/17.0.14-17.56-jre/Dockerfile
+++ b/centos/17.0.14-17.56-jre/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/17.0.14-17.56/Dockerfile
+++ b/centos/17.0.14-17.56/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/21-jre-headless-latest/Dockerfile
+++ b/centos/21-jre-headless-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/21-jre-latest/Dockerfile
+++ b/centos/21-jre-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/21-latest/Dockerfile
+++ b/centos/21-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/21.0.6-21.40-jre-headless/Dockerfile
+++ b/centos/21.0.6-21.40-jre-headless/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/21.0.6-21.40-jre/Dockerfile
+++ b/centos/21.0.6-21.40-jre/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/21.0.6-21.40/Dockerfile
+++ b/centos/21.0.6-21.40/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/22-jre-headless-latest/Dockerfile
+++ b/centos/22-jre-headless-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/22-jre-latest/Dockerfile
+++ b/centos/22-jre-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/22-latest/Dockerfile
+++ b/centos/22-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/22.0.2-22.32-jre-headless/Dockerfile
+++ b/centos/22.0.2-22.32-jre-headless/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/22.0.2-22.32-jre/Dockerfile
+++ b/centos/22.0.2-22.32-jre/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/22.0.2-22.32/Dockerfile
+++ b/centos/22.0.2-22.32/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/23-jre-headless-latest/Dockerfile
+++ b/centos/23-jre-headless-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/23-jre-latest/Dockerfile
+++ b/centos/23-jre-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/23-latest/Dockerfile
+++ b/centos/23-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/23.0.2-23.32-jre-headless/Dockerfile
+++ b/centos/23.0.2-23.32-jre-headless/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/23.0.2-23.32-jre/Dockerfile
+++ b/centos/23.0.2-23.32-jre/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/23.0.2-23.32/Dockerfile
+++ b/centos/23.0.2-23.32/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/24-jre-headless-latest/Dockerfile
+++ b/centos/24-jre-headless-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/24-jre-latest/Dockerfile
+++ b/centos/24-jre-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/24-latest/Dockerfile
+++ b/centos/24-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/24.0.0-24.28-jre-headless/Dockerfile
+++ b/centos/24.0.0-24.28-jre-headless/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/24.0.0-24.28-jre/Dockerfile
+++ b/centos/24.0.0-24.28-jre/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/24.0.0-24.28/Dockerfile
+++ b/centos/24.0.0-24.28/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/8-jre-headless-latest/Dockerfile
+++ b/centos/8-jre-headless-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/8-jre-latest/Dockerfile
+++ b/centos/8-jre-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/8-latest/Dockerfile
+++ b/centos/8-latest/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/8u442-8.84-jre-headless/Dockerfile
+++ b/centos/8u442-8.84-jre-headless/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/8u442-8.84-jre/Dockerfile
+++ b/centos/8u442-8.84-jre/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/centos/8u442-8.84/Dockerfile
+++ b/centos/8u442-8.84/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
 ARG ZULU_REPO_SHA256=2724b8be277ec16196b8e9357ed5e506eb791f88f966965a4f4a8bd5c4acdcfe
 ARG ZULU_REPO_VER=1.0.0-1
 
-RUN rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
+RUN set -ex && \
+    rpm --import https://repos.azulsystems.com/RPM-GPG-KEY-azulsystems && \
     curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \
     echo "${ZULU_REPO_SHA256}  zulu-repo-${ZULU_REPO_VER}.noarch.rpm" | sha256sum --strict --check - && \
     rpm -ivh zulu-repo-${ZULU_REPO_VER}.noarch.rpm && \

--- a/debian/11-jre-headless-latest/Dockerfile
+++ b/debian/11-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/debian/11-jre-latest/Dockerfile
+++ b/debian/11-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/debian/11-latest/Dockerfile
+++ b/debian/11-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/debian/11.0.26-11.78-jre-headless/Dockerfile
+++ b/debian/11.0.26-11.78-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/debian/11.0.26-11.78-jre/Dockerfile
+++ b/debian/11.0.26-11.78-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/debian/11.0.26-11.78/Dockerfile
+++ b/debian/11.0.26-11.78/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/debian/17-jre-headless-latest/Dockerfile
+++ b/debian/17-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/debian/17-jre-latest/Dockerfile
+++ b/debian/17-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/debian/17-latest/Dockerfile
+++ b/debian/17-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/debian/17.0.14-17.56-jre-headless/Dockerfile
+++ b/debian/17.0.14-17.56-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/debian/17.0.14-17.56-jre/Dockerfile
+++ b/debian/17.0.14-17.56-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/debian/17.0.14-17.56/Dockerfile
+++ b/debian/17.0.14-17.56/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/debian/21-jre-headless-latest/Dockerfile
+++ b/debian/21-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/debian/21-jre-latest/Dockerfile
+++ b/debian/21-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/debian/21-latest/Dockerfile
+++ b/debian/21-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/debian/21.0.6-21.40-jre-headless/Dockerfile
+++ b/debian/21.0.6-21.40-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/debian/21.0.6-21.40-jre/Dockerfile
+++ b/debian/21.0.6-21.40-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/debian/21.0.6-21.40/Dockerfile
+++ b/debian/21.0.6-21.40/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/debian/22-jre-headless-latest/Dockerfile
+++ b/debian/22-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/debian/22-jre-latest/Dockerfile
+++ b/debian/22-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/debian/22-latest/Dockerfile
+++ b/debian/22-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/debian/22.0.2-22.32-jre-headless/Dockerfile
+++ b/debian/22.0.2-22.32-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/debian/22.0.2-22.32-jre/Dockerfile
+++ b/debian/22.0.2-22.32-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/debian/22.0.2-22.32/Dockerfile
+++ b/debian/22.0.2-22.32/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/debian/23-jre-headless-latest/Dockerfile
+++ b/debian/23-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/debian/23-jre-latest/Dockerfile
+++ b/debian/23-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/debian/23-latest/Dockerfile
+++ b/debian/23-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/debian/23.0.2-23.32-jre-headless/Dockerfile
+++ b/debian/23.0.2-23.32-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/debian/23.0.2-23.32-jre/Dockerfile
+++ b/debian/23.0.2-23.32-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/debian/23.0.2-23.32/Dockerfile
+++ b/debian/23.0.2-23.32/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/debian/24-jre-headless-latest/Dockerfile
+++ b/debian/24-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/debian/24-jre-latest/Dockerfile
+++ b/debian/24-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/debian/24-latest/Dockerfile
+++ b/debian/24-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/debian/24.0.0-24.28-jre-headless/Dockerfile
+++ b/debian/24.0.0-24.28-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/debian/24.0.0-24.28-jre/Dockerfile
+++ b/debian/24.0.0-24.28-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/debian/24.0.0-24.28/Dockerfile
+++ b/debian/24.0.0-24.28/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/debian/8-jre-headless-latest/Dockerfile
+++ b/debian/8-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/debian/8-jre-latest/Dockerfile
+++ b/debian/8-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/debian/8-latest/Dockerfile
+++ b/debian/8-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/debian/8u442-8.84-jre-headless/Dockerfile
+++ b/debian/8u442-8.84-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/debian/8u442-8.84-jre/Dockerfile
+++ b/debian/8u442-8.84-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/debian/8u442-8.84/Dockerfile
+++ b/debian/8u442-8.84/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:bookworm-slim
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/distroless/17-latest/Dockerfile
+++ b/distroless/17-latest/Dockerfile
@@ -1,22 +1,18 @@
 FROM ubuntu:jammy AS builder
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17
 

--- a/distroless/17.0.14-17.56/Dockerfile
+++ b/distroless/17.0.14-17.56/Dockerfile
@@ -1,22 +1,18 @@
 FROM ubuntu:jammy AS builder
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17
 

--- a/distroless/21-latest/Dockerfile
+++ b/distroless/21-latest/Dockerfile
@@ -1,22 +1,18 @@
 FROM ubuntu:jammy AS builder
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21
 

--- a/distroless/21.0.6-21.40/Dockerfile
+++ b/distroless/21.0.6-21.40/Dockerfile
@@ -1,22 +1,18 @@
 FROM ubuntu:jammy AS builder
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV LANG='en_US.UTF-8'
 
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21
 

--- a/ubuntu/11-jre-headless-latest/Dockerfile
+++ b/ubuntu/11-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/ubuntu/11-jre-latest/Dockerfile
+++ b/ubuntu/11-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/ubuntu/11-latest/Dockerfile
+++ b/ubuntu/11-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/ubuntu/11.0.26-11.78-jre-headless/Dockerfile
+++ b/ubuntu/11.0.26-11.78-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/ubuntu/11.0.26-11.78-jre/Dockerfile
+++ b/ubuntu/11.0.26-11.78-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/ubuntu/11.0.26-11.78/Dockerfile
+++ b/ubuntu/11.0.26-11.78/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.26-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.26-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu11

--- a/ubuntu/17-jdk-crac-latest/Dockerfile
+++ b/ubuntu/17-jdk-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu17.56.15-ca-crac-jdk17.0.14-linux_aarch64 /opt/zulu17.56.15-ca-crac-jdk17.0.14-linux_aarch64
 ENV JAVA_HOME /opt/zulu17.56.15-ca-crac-jdk17.0.14-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/17-jre-crac-latest/Dockerfile
+++ b/ubuntu/17-jre-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu17.56.15-ca-crac-jre17.0.14-linux_aarch64 /opt/zulu17.56.15-ca-crac-jre17.0.14-linux_aarch64
 ENV JAVA_HOME /opt/zulu17.56.15-ca-crac-jre17.0.14-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/17-jre-headless-latest/Dockerfile
+++ b/ubuntu/17-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/ubuntu/17-jre-latest/Dockerfile
+++ b/ubuntu/17-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/ubuntu/17-latest/Dockerfile
+++ b/ubuntu/17-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/ubuntu/17.0.14-17.56-jdk-crac/Dockerfile
+++ b/ubuntu/17.0.14-17.56-jdk-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu17.56.15-ca-crac-jdk17.0.14-linux_aarch64 /opt/zulu17.56.15-ca-crac-jdk17.0.14-linux_aarch64
 ENV JAVA_HOME /opt/zulu17.56.15-ca-crac-jdk17.0.14-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/17.0.14-17.56-jre-crac/Dockerfile
+++ b/ubuntu/17.0.14-17.56-jre-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu17.56.15-ca-crac-jre17.0.14-linux_aarch64 /opt/zulu17.56.15-ca-crac-jre17.0.14-linux_aarch64
 ENV JAVA_HOME /opt/zulu17.56.15-ca-crac-jre17.0.14-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/17.0.14-17.56-jre-headless/Dockerfile
+++ b/ubuntu/17.0.14-17.56-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/ubuntu/17.0.14-17.56-jre/Dockerfile
+++ b/ubuntu/17.0.14-17.56-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/ubuntu/17.0.14-17.56/Dockerfile
+++ b/ubuntu/17.0.14-17.56/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.14-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.14-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/ubuntu/21-jdk-crac-latest/Dockerfile
+++ b/ubuntu/21-jdk-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu21.40.17-ca-crac-jdk21.0.6-linux_aarch64 /opt/zulu21.40.17-ca-crac-jdk21.0.6-linux_aarch64
 ENV JAVA_HOME /opt/zulu21.40.17-ca-crac-jdk21.0.6-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/21-jre-crac-latest/Dockerfile
+++ b/ubuntu/21-jre-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu21.40.17-ca-crac-jre21.0.6-linux_aarch64 /opt/zulu21.40.17-ca-crac-jre21.0.6-linux_aarch64
 ENV JAVA_HOME /opt/zulu21.40.17-ca-crac-jre21.0.6-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/21-jre-headless-latest/Dockerfile
+++ b/ubuntu/21-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/ubuntu/21-jre-latest/Dockerfile
+++ b/ubuntu/21-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/ubuntu/21-latest/Dockerfile
+++ b/ubuntu/21-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/ubuntu/21.0.6-21.40-jdk-crac/Dockerfile
+++ b/ubuntu/21.0.6-21.40-jdk-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu21.40.17-ca-crac-jdk21.0.6-linux_aarch64 /opt/zulu21.40.17-ca-crac-jdk21.0.6-linux_aarch64
 ENV JAVA_HOME /opt/zulu21.40.17-ca-crac-jdk21.0.6-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/21.0.6-21.40-jre-crac/Dockerfile
+++ b/ubuntu/21.0.6-21.40-jre-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu21.40.17-ca-crac-jre21.0.6-linux_aarch64 /opt/zulu21.40.17-ca-crac-jre21.0.6-linux_aarch64
 ENV JAVA_HOME /opt/zulu21.40.17-ca-crac-jre21.0.6-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/21.0.6-21.40-jre-headless/Dockerfile
+++ b/ubuntu/21.0.6-21.40-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/ubuntu/21.0.6-21.40-jre/Dockerfile
+++ b/ubuntu/21.0.6-21.40-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/ubuntu/21.0.6-21.40/Dockerfile
+++ b/ubuntu/21.0.6-21.40/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.6-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.6-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/ubuntu/22-jdk-crac-latest/Dockerfile
+++ b/ubuntu/22-jdk-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu22.32.21-ca-crac-jdk22.0.2-linux_aarch64 /opt/zulu22.32.21-ca-crac-jdk22.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu22.32.21-ca-crac-jdk22.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/22-jre-crac-latest/Dockerfile
+++ b/ubuntu/22-jre-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu22.32.21-ca-crac-jre22.0.2-linux_aarch64 /opt/zulu22.32.21-ca-crac-jre22.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu22.32.21-ca-crac-jre22.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/22-jre-headless-latest/Dockerfile
+++ b/ubuntu/22-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/ubuntu/22-jre-latest/Dockerfile
+++ b/ubuntu/22-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/ubuntu/22-latest/Dockerfile
+++ b/ubuntu/22-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/ubuntu/22.0.2-22.32-jdk-crac/Dockerfile
+++ b/ubuntu/22.0.2-22.32-jdk-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu22.32.21-ca-crac-jdk22.0.2-linux_aarch64 /opt/zulu22.32.21-ca-crac-jdk22.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu22.32.21-ca-crac-jdk22.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/22.0.2-22.32-jre-crac/Dockerfile
+++ b/ubuntu/22.0.2-22.32-jre-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu22.32.21-ca-crac-jre22.0.2-linux_aarch64 /opt/zulu22.32.21-ca-crac-jre22.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu22.32.21-ca-crac-jre22.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/22.0.2-22.32-jre-headless/Dockerfile
+++ b/ubuntu/22.0.2-22.32-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/ubuntu/22.0.2-22.32-jre/Dockerfile
+++ b/ubuntu/22.0.2-22.32-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/ubuntu/22.0.2-22.32/Dockerfile
+++ b/ubuntu/22.0.2-22.32/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu22

--- a/ubuntu/23-jdk-crac-latest/Dockerfile
+++ b/ubuntu/23-jdk-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu23.32.11-ca-crac-jdk23.0.2-linux_aarch64 /opt/zulu23.32.11-ca-crac-jdk23.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu23.32.11-ca-crac-jdk23.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/23-jre-crac-latest/Dockerfile
+++ b/ubuntu/23-jre-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu23.32.11-ca-crac-jre23.0.2-linux_aarch64 /opt/zulu23.32.11-ca-crac-jre23.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu23.32.11-ca-crac-jre23.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/23-jre-headless-latest/Dockerfile
+++ b/ubuntu/23-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/ubuntu/23-jre-latest/Dockerfile
+++ b/ubuntu/23-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/ubuntu/23-latest/Dockerfile
+++ b/ubuntu/23-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/ubuntu/23.0.2-23.32-jdk-crac/Dockerfile
+++ b/ubuntu/23.0.2-23.32-jdk-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu23.32.11-ca-crac-jdk23.0.2-linux_aarch64 /opt/zulu23.32.11-ca-crac-jdk23.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu23.32.11-ca-crac-jdk23.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/23.0.2-23.32-jre-crac/Dockerfile
+++ b/ubuntu/23.0.2-23.32-jre-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu23.32.11-ca-crac-jre23.0.2-linux_aarch64 /opt/zulu23.32.11-ca-crac-jre23.0.2-linux_aarch64
 ENV JAVA_HOME /opt/zulu23.32.11-ca-crac-jre23.0.2-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/23.0.2-23.32-jre-headless/Dockerfile
+++ b/ubuntu/23.0.2-23.32-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/ubuntu/23.0.2-23.32-jre/Dockerfile
+++ b/ubuntu/23.0.2-23.32-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/ubuntu/23.0.2-23.32/Dockerfile
+++ b/ubuntu/23.0.2-23.32/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu23

--- a/ubuntu/24-jdk-crac-latest/Dockerfile
+++ b/ubuntu/24-jdk-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu24.28.87-ca-crac-jdk24.0.0-linux_aarch64 /opt/zulu24.28.87-ca-crac-jdk24.0.0-linux_aarch64
 ENV JAVA_HOME /opt/zulu24.28.87-ca-crac-jdk24.0.0-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/24-jre-crac-latest/Dockerfile
+++ b/ubuntu/24-jre-crac-latest/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu24.28.87-ca-crac-jre24.0.0-linux_aarch64 /opt/zulu24.28.87-ca-crac-jre24.0.0-linux_aarch64
 ENV JAVA_HOME /opt/zulu24.28.87-ca-crac-jre24.0.0-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/24-jre-headless-latest/Dockerfile
+++ b/ubuntu/24-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/ubuntu/24-jre-latest/Dockerfile
+++ b/ubuntu/24-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/ubuntu/24-latest/Dockerfile
+++ b/ubuntu/24-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/ubuntu/24.0.0-24.28-jdk-crac/Dockerfile
+++ b/ubuntu/24.0.0-24.28-jdk-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu24.28.87-ca-crac-jdk24.0.0-linux_aarch64 /opt/zulu24.28.87-ca-crac-jdk24.0.0-linux_aarch64
 ENV JAVA_HOME /opt/zulu24.28.87-ca-crac-jdk24.0.0-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/24.0.0-24.28-jre-crac/Dockerfile
+++ b/ubuntu/24.0.0-24.28-jre-crac/Dockerfile
@@ -6,10 +6,12 @@ FROM ubuntu:22.04
 COPY --from=builder /opt/zulu24.28.87-ca-crac-jre24.0.0-linux_aarch64 /opt/zulu24.28.87-ca-crac-jre24.0.0-linux_aarch64
 ENV JAVA_HOME /opt/zulu24.28.87-ca-crac-jre24.0.0-linux_aarch64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get -qq update && \
+RUN set -ex && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install locales tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
     apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu/24.0.0-24.28-jre-headless/Dockerfile
+++ b/ubuntu/24.0.0-24.28-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/ubuntu/24.0.0-24.28-jre/Dockerfile
+++ b/ubuntu/24.0.0-24.28-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/ubuntu/24.0.0-24.28/Dockerfile
+++ b/ubuntu/24.0.0-24.28/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu24

--- a/ubuntu/8-jre-headless-latest/Dockerfile
+++ b/ubuntu/8-jre-headless-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/ubuntu/8-jre-latest/Dockerfile
+++ b/ubuntu/8-jre-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/ubuntu/8-latest/Dockerfile
+++ b/ubuntu/8-latest/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/ubuntu/8u442-8.84-jre-headless/Dockerfile
+++ b/ubuntu/8u442-8.84-jre-headless/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/ubuntu/8u442-8.84-jre/Dockerfile
+++ b/ubuntu/8u442-8.84-jre/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8

--- a/ubuntu/8u442-8.84/Dockerfile
+++ b/ubuntu/8u442-8.84/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:jammy
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
-ARG ZULU_REPO_SHA256=d08d9610c093b0954c6b278ecc628736e303634331641142fa5096396201f49c
-
-RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata && \
+ENV LANG='en_US.UTF-8'
+RUN set -ex && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && \
-    echo "${ZULU_REPO_SHA256} zulu-repo_${ZULU_REPO_VER}_all.deb" | sha256sum --strict --check - && \
-    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.442-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.442-* && \
-    apt-get -qq -y purge --auto-remove gnupg software-properties-common curl && \
+    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
     apt-get -qq -y dist-upgrade && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu8


### PR DESCRIPTION
This MR introduces some improvements to docker images. All -latest images are affected.

1. Reduced verbosity for locale settings
(removed ENV LANGUAGE en_US:en & ENV LC_ALL en_US.UTF-8 from all images; ENV LANG en_US.UTF-8 remains)

2.Removed unnecessary timezone setting
(ENV TZ=Etc/UTC)

3. Removed usage of deprecated apt-key from debian-based images. This means that
`apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \ `
is replaced with
` curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \`

4. Removed installation of software-properties-common. Added ca-certificates only as replacement

5. Replaced dpkg usage with apt-get

6. Added set -ex to the beginning of each RUN command for easier debugging of failed image builds