### PR TITLE
Revert ca-certificates removal

### DIFF
--- a/debian/11-jre-headless-latest/Dockerfile
+++ b/debian/11-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/11-jre-latest/Dockerfile
+++ b/debian/11-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/11-latest/Dockerfile
+++ b/debian/11-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/11.0.27-11.80-jre-headless/Dockerfile
+++ b/debian/11.0.27-11.80-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/11.0.27-11.80-jre/Dockerfile
+++ b/debian/11.0.27-11.80-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/11.0.27-11.80/Dockerfile
+++ b/debian/11.0.27-11.80/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/17-jre-headless-latest/Dockerfile
+++ b/debian/17-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/17-jre-latest/Dockerfile
+++ b/debian/17-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/17-latest/Dockerfile
+++ b/debian/17-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/17.0.15-17.58-jre-headless/Dockerfile
+++ b/debian/17.0.15-17.58-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/17.0.15-17.58-jre/Dockerfile
+++ b/debian/17.0.15-17.58-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/17.0.15-17.58/Dockerfile
+++ b/debian/17.0.15-17.58/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/21-jre-headless-latest/Dockerfile
+++ b/debian/21-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/21-jre-latest/Dockerfile
+++ b/debian/21-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/21-latest/Dockerfile
+++ b/debian/21-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/21.0.7-21.42-jre-headless/Dockerfile
+++ b/debian/21.0.7-21.42-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/21.0.7-21.42-jre/Dockerfile
+++ b/debian/21.0.7-21.42-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/21.0.7-21.42/Dockerfile
+++ b/debian/21.0.7-21.42/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/22-jre-headless-latest/Dockerfile
+++ b/debian/22-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/22-jre-latest/Dockerfile
+++ b/debian/22-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/22-latest/Dockerfile
+++ b/debian/22-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/22.0.2-22.32-jre-headless/Dockerfile
+++ b/debian/22.0.2-22.32-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/22.0.2-22.32-jre/Dockerfile
+++ b/debian/22.0.2-22.32-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/22.0.2-22.32/Dockerfile
+++ b/debian/22.0.2-22.32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/23-jre-headless-latest/Dockerfile
+++ b/debian/23-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/23-jre-latest/Dockerfile
+++ b/debian/23-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/23-latest/Dockerfile
+++ b/debian/23-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/23.0.2-23.32-jre-headless/Dockerfile
+++ b/debian/23.0.2-23.32-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/23.0.2-23.32-jre/Dockerfile
+++ b/debian/23.0.2-23.32-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/23.0.2-23.32/Dockerfile
+++ b/debian/23.0.2-23.32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/24-jre-headless-latest/Dockerfile
+++ b/debian/24-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/24-jre-latest/Dockerfile
+++ b/debian/24-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/24-latest/Dockerfile
+++ b/debian/24-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/24.0.1-24.30-jre-headless/Dockerfile
+++ b/debian/24.0.1-24.30-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/24.0.1-24.30-jre/Dockerfile
+++ b/debian/24.0.1-24.30-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/24.0.1-24.30/Dockerfile
+++ b/debian/24.0.1-24.30/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/8-jre-headless-latest/Dockerfile
+++ b/debian/8-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/8-jre-latest/Dockerfile
+++ b/debian/8-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/8-latest/Dockerfile
+++ b/debian/8-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/8u452-8.86-jre-headless/Dockerfile
+++ b/debian/8u452-8.86-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/8u452-8.86-jre/Dockerfile
+++ b/debian/8u452-8.86-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/debian/8u452-8.86/Dockerfile
+++ b/debian/8u452-8.86/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/distroless/17-latest/Dockerfile
+++ b/distroless/17-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/distroless/17.0.15-17.58/Dockerfile
+++ b/distroless/17.0.15-17.58/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu17

--- a/distroless/21-latest/Dockerfile
+++ b/distroless/21-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/distroless/21.0.7-21.42/Dockerfile
+++ b/distroless/21.0.7-21.42/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/zulu21

--- a/ubuntu/11-jre-headless-latest/Dockerfile
+++ b/ubuntu/11-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/11-jre-latest/Dockerfile
+++ b/ubuntu/11-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/11-latest/Dockerfile
+++ b/ubuntu/11-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/11.0.27-11.80-jre-headless/Dockerfile
+++ b/ubuntu/11.0.27-11.80-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre-headless=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/11.0.27-11.80-jre/Dockerfile
+++ b/ubuntu/11.0.27-11.80-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jre=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/11.0.27-11.80/Dockerfile
+++ b/ubuntu/11.0.27-11.80/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu11-*\nPin: version 11.0.27-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu11-jdk=11.0.27-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/17-jre-headless-latest/Dockerfile
+++ b/ubuntu/17-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/17-jre-latest/Dockerfile
+++ b/ubuntu/17-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/17-latest/Dockerfile
+++ b/ubuntu/17-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/17.0.15-17.58-jre-headless/Dockerfile
+++ b/ubuntu/17.0.15-17.58-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre-headless=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/17.0.15-17.58-jre/Dockerfile
+++ b/ubuntu/17.0.15-17.58-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jre=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/17.0.15-17.58/Dockerfile
+++ b/ubuntu/17.0.15-17.58/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu17-*\nPin: version 17.0.15-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.15-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/21-jre-headless-latest/Dockerfile
+++ b/ubuntu/21-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/21-jre-latest/Dockerfile
+++ b/ubuntu/21-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/21-latest/Dockerfile
+++ b/ubuntu/21-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/21.0.7-21.42-jre-headless/Dockerfile
+++ b/ubuntu/21.0.7-21.42-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre-headless=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/21.0.7-21.42-jre/Dockerfile
+++ b/ubuntu/21.0.7-21.42-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jre=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/21.0.7-21.42/Dockerfile
+++ b/ubuntu/21.0.7-21.42/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu21-*\nPin: version 21.0.7-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu21-jdk=21.0.7-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/22-jre-headless-latest/Dockerfile
+++ b/ubuntu/22-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/22-jre-latest/Dockerfile
+++ b/ubuntu/22-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/22-latest/Dockerfile
+++ b/ubuntu/22-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/22.0.2-22.32-jre-headless/Dockerfile
+++ b/ubuntu/22.0.2-22.32-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre-headless=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/22.0.2-22.32-jre/Dockerfile
+++ b/ubuntu/22.0.2-22.32-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jre=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/22.0.2-22.32/Dockerfile
+++ b/ubuntu/22.0.2-22.32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu22-*\nPin: version 22.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu22-jdk=22.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/23-jre-headless-latest/Dockerfile
+++ b/ubuntu/23-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/23-jre-latest/Dockerfile
+++ b/ubuntu/23-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/23-latest/Dockerfile
+++ b/ubuntu/23-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/23.0.2-23.32-jre-headless/Dockerfile
+++ b/ubuntu/23.0.2-23.32-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre-headless=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/23.0.2-23.32-jre/Dockerfile
+++ b/ubuntu/23.0.2-23.32-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jre=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/23.0.2-23.32/Dockerfile
+++ b/ubuntu/23.0.2-23.32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu23-*\nPin: version 23.0.2-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu23-jdk=23.0.2-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/24-jre-headless-latest/Dockerfile
+++ b/ubuntu/24-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/24-jre-latest/Dockerfile
+++ b/ubuntu/24-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/24-latest/Dockerfile
+++ b/ubuntu/24-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/24.0.1-24.30-jre-headless/Dockerfile
+++ b/ubuntu/24.0.1-24.30-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre-headless=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/24.0.1-24.30-jre/Dockerfile
+++ b/ubuntu/24.0.1-24.30-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jre=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/24.0.1-24.30/Dockerfile
+++ b/ubuntu/24.0.1-24.30/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu24-*\nPin: version 24.0.1-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu24-jdk=24.0.1-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/8-jre-headless-latest/Dockerfile
+++ b/ubuntu/8-jre-headless-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/8-jre-latest/Dockerfile
+++ b/ubuntu/8-jre-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/8-latest/Dockerfile
+++ b/ubuntu/8-latest/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/8u452-8.86-jre-headless/Dockerfile
+++ b/ubuntu/8u452-8.86-jre-headless/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre-headless=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/8u452-8.86-jre/Dockerfile
+++ b/ubuntu/8u452-8.86-jre/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jre=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \

--- a/ubuntu/8u452-8.86/Dockerfile
+++ b/ubuntu/8u452-8.86/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     apt-get -qq update && \
     echo "Package: zulu8-*\nPin: version 8.0.452-*\nPin-Priority: 1001" > /etc/apt/preferences && \
     apt-get -qq -y --no-install-recommends install zulu8-jdk=8.0.452-* && \
-    apt-get -qq -y purge --auto-remove gnupg ca-certificates curl && \
+    apt-get -qq -y purge --auto-remove gnupg curl && \
     apt-get -qq -y dist-upgrade && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && \


### PR DESCRIPTION
MR https://github.com/zulu-openjdk/zulu-openjdk/pull/306 introduced multiple changes for image improvements. One of the goals was to strip images down to the bare minimum required to run Azul Zulu Java.

Based on the user feedback, removal of ca-certificates led to inconvenience as there are justified expectations that this package is available out-of-the box on debian-based systems.

Therefore, this MR reverts this package removal.