### PR TITLE
Update Debian base image from bookworm-slim to trixie-slim for -lates…

### DIFF
--- a/debian/11-jre-headless-latest/Dockerfile
+++ b/debian/11-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/11-jre-latest/Dockerfile
+++ b/debian/11-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/11-latest/Dockerfile
+++ b/debian/11-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/17-jre-headless-latest/Dockerfile
+++ b/debian/17-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/17-jre-latest/Dockerfile
+++ b/debian/17-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/17-latest/Dockerfile
+++ b/debian/17-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/21-jre-headless-latest/Dockerfile
+++ b/debian/21-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/21-jre-latest/Dockerfile
+++ b/debian/21-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/21-latest/Dockerfile
+++ b/debian/21-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/22-jre-headless-latest/Dockerfile
+++ b/debian/22-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/22-jre-latest/Dockerfile
+++ b/debian/22-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/22-latest/Dockerfile
+++ b/debian/22-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/23-jre-headless-latest/Dockerfile
+++ b/debian/23-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/23-jre-latest/Dockerfile
+++ b/debian/23-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/23-latest/Dockerfile
+++ b/debian/23-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/24-jre-headless-latest/Dockerfile
+++ b/debian/24-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/24-jre-latest/Dockerfile
+++ b/debian/24-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/24-latest/Dockerfile
+++ b/debian/24-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/8-jre-headless-latest/Dockerfile
+++ b/debian/8-jre-headless-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/8-jre-latest/Dockerfile
+++ b/debian/8-jre-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \

--- a/debian/8-latest/Dockerfile
+++ b/debian/8-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV LANG='en_US.UTF-8'
 RUN set -ex && \


### PR DESCRIPTION
…t images

To keep changes low/conservative, this migrates only the 21 -latest Dockerfiles to use debian:trixie-slim (Debian 13 / current stable). trixie became stable on [August 9](https://www.debian.org/News/2025/20250809).

Verified that all 21 images built successfully, and did a super basic test to make sure `java -version` is runnable in the container.

PS -- I was not a 100% sure if I should be modifying the version specific Dockerfiles (ones that use debian:bookworm-slim) or not, so I left all those as-is.